### PR TITLE
fix: Always disable Temporal Filtering on AmplifyOcclusion

### DIFF
--- a/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
+++ b/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
@@ -141,11 +141,12 @@ public class CameraPostprocessingManager : MonoBehaviour
         _ao.Radius = 4;
         _ao.PowerExponent = 0.6f;
 
+        _ao.FilterEnabled = false;
+
         _ao.SampleCount = AmplifyOcclusion.SampleCountLevel.Low;
 
         if (!IsPrimary)
         {
-            _ao.FilterEnabled = false;
             _ao.BlurPasses = 4;
             _ao.BlurRadius = 4;
             _ao.BlurSharpness = 3;

--- a/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
+++ b/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
@@ -143,6 +143,12 @@ public class CameraPostprocessingManager : MonoBehaviour
 
         _ao.FilterEnabled = false;
 
+        // Enable distance fading to reduce unwanted flickering at long distances
+        _ao.FadeEnabled = true;
+
+        _ao.FadeStart = 16.0f;
+        _ao.FadeLength = 128.0f;
+
         _ao.SampleCount = AmplifyOcclusion.SampleCountLevel.Low;
 
         if (!IsPrimary)
@@ -154,11 +160,8 @@ public class CameraPostprocessingManager : MonoBehaviour
         else
         {
             _ao.BlurPasses = 2;
-            _ao.BlurSharpness = 3;
             _ao.BlurRadius = 4;
-
-            _ao.FilterResponse = 0.9f;
-            _ao.FilterBlending = 0.25f;
+            _ao.BlurSharpness = 3;
         }
     }
 


### PR DESCRIPTION
With the migration to the newer, open-source variant of Amplify Occlusion, the Temporal Filter seems to cause more issues than it truly fixes in VR.

I created a test scene replicating all the post-processing and AO settings that Renderite utilizes, then compared how the Ambient Occlusion effect behaves with the Temporal Filter enabled and disabled, and it often seems to create black blobs and color banding between objects.

Temporal Filter Enabled  |  Temporal Filter Disabled
:----:  |  :----:
<img width="1831" height="1830" alt="20260418140102_1" src="https://github.com/user-attachments/assets/39e079d5-3f31-4912-8f1e-bfe4e11a719d" /> | <img width="1831" height="1830" alt="20260418140103_1" src="https://github.com/user-attachments/assets/b0f70658-d14c-4871-acca-cb6c4972f81f" />

I've compiled the renderer with my minor change and observed that it effectively fixed these two issues:
- https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6462
- https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6469

Another positive effect of this change is reducing the ghosts or smearing artifacts on moving or vanishing objects, and the original negative side-effect of the AO flickering or looking fuzzy without Temporal Filtering seems to be nearly imperceivable with this variant of Amplify Occlusion.