### PR TITLE
add clone instructions to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Making this repository open source has several goals:
 - SDK for building Resonite content with Unity
     - Unity SDK is a completely separate project available here: https://github.com/Yellow-Dog-Man/Resonite.UnitySDK
 
+# Cloning the repo
+This repo has GitLFS files and thusly, requires Git LFS to be installed alongside the Git CLI. More info about GitLFS avalible here: https://git-lfs.com/
+
+- Git for Windows comes with Git LFS installed by default.
+- Linux 
+   - Arch; git-lfs is available in the extra repo:
+    `pacman -S git-lfs`
+   - Ubuntu/Debian:
+    `apt install git-lfs`
+   - Fedora/RHEL:
+    `dnf install git-lfs` 
+- Once Downloaded on Linux, run `git lfs install` in the terminal to finish the install.
+
 # Building
 Unity Version: Unity 2019.4f19
 


### PR DESCRIPTION
Git LFS is needed to clone the repo, as such i have added instructions for using git-lfs and where to *git* it from

## Motivation
Update Readme to include disclaimer about needing gitlfs 

### Related GitHub issues
#8

## Notable Changes
updated Readme.md

## Testing
n/a

## Backwards Compatibility
n/a