### PR TITLE
Patch build issue on MRs coming from forked repositories

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Motivation

When getting MRs to this repository coming from forks, the pipelines will fail due to the repository secrets not being in the correct scope:
- https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/actions/runs/24652461432
- https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/actions/runs/24535425286

### Related GitHub issues

N/A

## Notable Changes

Build workflow now uses `pull_request_target`, which will run the build against our repository instead of the remote fork.

We need the secret context to be in our repository for the build to run, as Unity needs a licence activation step to build the renderer.

## Testing

Awaiting pipeline.

## Backwards Compatibility

No backwards compatibility issues.