### PR TITLE
Make UnityWindowsExtensions' marshalled delegates static

### DIFF
--- a/Assets/APP/Unity Environment/B83.Win32.cs
+++ b/Assets/APP/Unity Environment/B83.Win32.cs
@@ -28,6 +28,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Renderite.Unity;
+using UnityEngine;
 
 namespace B83.Win32
 {
@@ -422,31 +425,43 @@ namespace B83.Win32
 
         private uint threadId = WinAPI.GetCurrentThreadId();
         private IntPtr mainWindow;
-        private HookProc m_Callback;
         private IntPtr m_Hook;
+        private const string unityClassName = "UnityWndClass";
+        
+        // SetWindowsHookEx doesn't have a variant with userdata,
+        // so we have to hack around it with a singleton to get the current class instance in the hook.
+        private static UnityWindowsExtensions m_Instance;
 
         public UnityWindowsExtensions()
         {
             if (threadId > 0)
-                mainWindow = GetMainWindow(threadId, "UnityWndClass");
+                mainWindow = GetMainWindow(threadId);
+            
+            if(m_Instance != null)
+                Debug.LogWarning("Created multiple UnityWindowsExtensions instances.");
+
+            m_Instance = this;
         }
 
-        public static IntPtr GetMainWindow(uint aThreadId, string aClassName = null)
+        public static unsafe IntPtr GetMainWindow(uint aThreadId)
         {
             IntPtr win = IntPtr.Zero;
-            Window.EnumThreadWindows(aThreadId, (W, _) => {
-                if (Window.IsWindowVisible(W) && (win == null || (aClassName != null && Window.GetClassName(W) == aClassName)))
-                    win = W;
-                return true;
-            }, IntPtr.Zero);
+            Window.EnumThreadWindows(aThreadId, MainWindowPredicate, (IntPtr)(&win));
             return win;
         }
-
+        
+        [MonoPInvokeCallback(typeof(EnumThreadDelegate))]
+        private static unsafe bool MainWindowPredicate(IntPtr w, IntPtr winPtr)
+        {
+            IntPtr* win = (IntPtr*)winPtr;
+            if (Window.IsWindowVisible(w) && (*win == null || (unityClassName != null && Window.GetClassName(w) == unityClassName))) *win = w;
+            return true;
+        }
+        
         public void InstallHook()
         {
             var hModule = WinAPI.GetModuleHandle(null);
-            m_Callback = Callback;
-            m_Hook = WinAPI.SetWindowsHookEx(HookType.WH_GETMESSAGE, m_Callback, hModule, threadId);
+            m_Hook = WinAPI.SetWindowsHookEx(HookType.WH_GETMESSAGE, Callback, hModule, threadId);
             // Allow dragging of files onto the main window. generates the WM_DROPFILES message
             WinAPI.DragAcceptFiles(mainWindow, true);
         }
@@ -470,7 +485,8 @@ namespace B83.Win32
             WinAPI.SetForegroundWindow(handle);
         }
 
-        private IntPtr Callback(int code, IntPtr wParam, ref MSG lParam)
+        [MonoPInvokeCallback(typeof(HookProc))]
+        private static IntPtr Callback(int code, IntPtr wParam, ref MSG lParam)
         {
             if (code == 0 && lParam.message == WM.DROPFILES)
             {
@@ -489,10 +505,10 @@ namespace B83.Win32
                     sb.Length = 0;
                 }
                 WinAPI.DragFinish(lParam.wParam);
-                if (OnDroppedFiles != null)
-                    OnDroppedFiles(result, pos);
+                if (m_Instance.OnDroppedFiles != null)
+                    m_Instance.OnDroppedFiles(result, pos);
             }
-            return WinAPI.CallNextHookEx(m_Hook, code, wParam, ref lParam);
+            return WinAPI.CallNextHookEx(m_Instance.m_Hook, code, wParam, ref lParam);
         }
 #else
         public void InstallHook()


### PR DESCRIPTION
## Motivation
The `UnityWindowsExtensions` class that hooks into the main window for supporting file drops currently uses some marshalling features that are unsupported and cause an exception in IL2CPP. Particularly, the ability to marshal a delegate while also having it be an instance method is unsupported.

To fix, rewrite the offending methods to use static methods instead.

### Related GitHub issues
https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/2

## Notable Changes
This requires us to store a singleton of `UnityWindowsExtensions` since the `SetWindowsHookEx` function doesn't allow us to include any `userdata` which we can use to reference the current instance inside the actual hook function. I normally don't like using singletons but in this case it should be OK since `UnityWindowsExtensions` should only ever be constructed once.

If you want I can also consider making the whole class static. I just went for the path of least resistance.

## Testing
- Windows x64 IL2CPP

I can't actually get a proper Mono environment working, since I have to use the latest version of 2019.4 to get Unity working at all due to some weird licensing shenanigans (the correct version simply refuses to activate)

The latest Unity version seems to crash somewhere in Mono. If someone could build this branch on the appropriate Unity version and test that would be greatly appreciated. Even rolling back my changes doesn't work so I'm thinking that must be the cause :pray:

## Backwards Compatibility
These changes are not expected to break anything, but I do recommend that they be tested.