### PR TITLE
Fix IL2CPP Master comipling as Release

### DIFF
--- a/Assets/APP/Editor/AppBuilder.cs
+++ b/Assets/APP/Editor/AppBuilder.cs
@@ -63,7 +63,7 @@ public class AppBuilder
     [MenuItem("Build/Windows (IL2CPP) - Master")]
     public static void BuildWindowsIL2CPP_Master()
     {
-        PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Standalone, Il2CppCompilerConfiguration.Release);
+        PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Standalone, Il2CppCompilerConfiguration.Master);
         BuildWindows(WindowsIL2CPP_Root, ScriptingImplementation.IL2CPP);
     }
 


### PR DESCRIPTION
## Motivation
With the current push on IL2CPP, I noticed a small mistake, where Master IL2CPP wouldn't actually compile as master.

### Related GitHub issues
N/A

## Notable Changes
Small change - Master actually compiles as Master.

## Testing
Made a build with this off a branch for prerelease.

## Backwards Compatibility
Not affected