### PR TITLE
CI/CD security scoping improvements

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,48 +21,38 @@ jobs:
     name: 'Build the Unity Runtime'
     runs-on: ubuntu-latest
 
-    steps:
-      - name: 'Checkout composite actions'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: |
-            .github
+    environment: ${{ github.event.pull_request.head.repo.fork == 'true' && 'MR' || 'Production' }}
 
+    env:
+      IS_EXTERNAL: ${{ github.event.pull_request.head.repo.fork == 'true' }}
+
+    steps:
       - name: 'Generate a token'
         id: generate-token
-        if: github.event_name != 'pull_request'
+        if: ${{ env.IS_EXTERNAL != 'true' }}
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_CLONE_TOKEN_ID }}
+          private-key: ${{ secrets.GH_APP_CLONE_TOKEN_SECRET }}
           owner: ${{ github.repository_owner }}
+          repositories:
+            Renderite.Unity.Renderer.UMP
 
       - name: 'Mask generated variable'
-        if: github.event_name != 'pull_request'
+        if: ${{ env.IS_EXTERNAL != 'true' }}
         shell: bash
         run: echo "::add-mask::${{ steps.generate-token.outputs.token }}"
-
-      - name: 'Determine token to use'
-        id: token-determination
-        run: |
-          TOKEN="${{ github.token }}"
-
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            TOKEN="${{ steps.generate-token.outputs.token }}"
-          fi
-
-          echo "token=$TOKEN" >> $GITHUB_OUTPUT
 
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: 'true'
           path: 'UnityRuntime'
-          token: '${{ steps.token-determination.outputs.token }}'
+          token: ${{ env.IS_EXTERNAL == 'true' && github.token || steps.generate-token.outputs.token }}
           submodules: ${{ github.event_name != 'pull_request' }}
 
       - name: 'Remove UMP Directory on external PR'
-        if: github.event_name == 'pull_request'
+        if: ${{ env.IS_EXTERNAL == 'true' }}
         working-directory: 'UnityRuntime'
         run: rm -rf Assets/UniversalMediaPlayer
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS FILE
+
+# Basic repository rule
+*                       @Yellow-Dog-Man/Engineering
+
+# GitHub Actions-specific
+/.github/workflows/     @jae1911


### PR DESCRIPTION
## Motivation

Improve the overall workflow security by adding more guardrails.

### Related GitHub issues

N/A.

## Notable Changes

From commit:

```
Reworks the logic for external MRs as to avoid security issues down the
line.

Builds will now feature two environments:
- Production, which will run on internal MRs and branch pushes.
- MR which will run on external MRs.

The Production environment exposes a new GitHub App which is scoped to
the submodule repository only to reduce the surface of attack if the
tokens were to be leaked.

Workflow runs for the MR environments are also on a 15 minutes timer and
strict approval. The timer is there to make sure the maintainer will
review changes correctly.

The MR environment doesn't exposes any secrets beyond the dummy Unity
account required to activate a personal license on build.

A new environment variable IS_EXTERNAL is now introduced to the workflow
which tells if the change is coming from an external MR.

This is now used to skip token generation and submodule checkout in this
case.

The GitHub Actions checkout has also been removed as Composite Actions
are not in use this this repository.

The CODEOWNERS file has been introduced to help with reviews and pinging
the right teams, especially in case of changes to GitHub Actions.
```

## Testing

- https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/actions/runs/25128591984/job/73648395199

## Backwards Compatibility

N/A

## If there are any, what steps did you take to prevent breakage?

N/A