### PR TITLE
Update Renderite to 1.0.5

### DIFF
--- a/Assets/APP/Renderite/Renderite.Shared.dll
+++ b/Assets/APP/Renderite/Renderite.Shared.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1eb2ce7eec88397073c146b3c74dc4fd45e229debfb578b0db6cb98a313cdc2f
+oid sha256:542c501bfb17887f3c602b031388b05a57eccfa193c5f0061566de1663ec508b
 size 122880

--- a/Assets/APP/Renderite/Renderite.Unity.dll
+++ b/Assets/APP/Renderite/Renderite.Unity.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:540949f42a459bd880fab89e27a7e9fb5071f574f59fa79c76df3d1d512cebda
-size 239104
+oid sha256:a79695040ef4e65855f0da34c5e460b159b7db6e56eb8695de8e218cc889cb45
+size 238592


### PR DESCRIPTION
## Motivation
Merging in the latest changes

### Related GitHub issues
https://github.com/Yellow-Dog-Man/Renderite/releases/tag/1.0.5

## Notable Changes
Supports transparency for screen blit

## Testing
Was done in the Renderite PR

## Backwards Compatibility
Not expected to break anything.