### PR TITLE
SteamVR: enable bound hand when Touch skeleton pose is invalid

### DIFF
--- a/Assets/APP/Unity Environment/InputOutputDrivers/SteamVRDriver.cs
+++ b/Assets/APP/Unity Environment/InputOutputDrivers/SteamVRDriver.cs
@@ -1436,9 +1436,15 @@ public class SteamVRDriver : InputDriver, IDriverHeadDevice, IOutputDriver
 
         if (!skeleton.activeBinding || !skeleton.poseIsValid)
         {
+            if (controller is TouchControllerState touch && controller.isTracking && !DisableSkeletalModel)
+                touch.hasBoundHand = true;
+            
             hand.isTracking = false;
             return;
         }
+
+        if (controller is TouchControllerState touchWithSkeleton)
+            touchWithSkeleton.hasBoundHand = DisableSkeletalModel;
 
         if (!controller.isTracking)
             return;


### PR DESCRIPTION
## Motivation
When using SteamVR with Lighthouse tracking and controllers that are emulated as Oculus Touch (e.g. Quest-style render models via third-party drivers), controller pose and buttons work, but avatar hands stay frozen and do not follow the controllers.

Investigation showed that `SteamVRDriver.UpdateHand` requires both `skeleton.activeBinding` and `skeleton.poseIsValid`. In this setup, `poseIsValid` remains false while `Generic.Pose` tracking for the controller is valid.

In this Lighthouse + Touch-emulation configuration, the device/driver stack does not provide usable SteamVR skeleton/hand-tracking data to the renderer (there is no practical path to supply hand skeleton data through the Lighthouse tracking pipeline from the device firmware). The renderer therefore never enables hand tracking via `HandState`, and `hasBoundHand` stays false unless `DisableSkeletalModel` is set for other HMD paths (ALVR, etc.).

This PR enables the existing controller-bound hand fallback (`VR_ControllerState.hasBoundHand` + `handPosition` / `handRotation` from `InitHandData`) when Touch skeleton data is unavailable but controller tracking is active.

### Related GitHub issues
[FlipVR Controllers Do Not Track Position/Rotation #2606
](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2606)

## Notable Changes
- SteamVRDriver.UpdateHand only (no FrooxEngine / Renderite.Shared changes).
- When `OculusTouch` skeleton is not ready (`!activeBinding || !poseIsValid`) and the controller is `TouchControllerState` with `controller.isTracking` and `!DisableSkeletalModel`:
   + set `touch.hasBoundHand = true` so FrooxEngine uses the preconfigured bound-hand offsets on the controller state.
   + keep `hand.isTracking = false` (no partial / empty skeleton finger data sent).
- When skeleton becomes valid again, reset `touch.hasBoundHand = DisableSkeletalModel` so normal finger tracking paths are unchanged where skeleton works.

## Testing
- [x] Lighthouse + emulated Oculus Touch (e.g. Shiftall GripVR with Quest controller profile): hands follow controllers; no longer frozen at desktop pose.
- [x]  Native Oculus Touch / Quest Link with valid skeleton: not tested (no hardware in this environment).

## Backwards Compatibility
These changes are not expected to break anything outside the targeted failure mode.

- The new behavior only runs when Touch skeleton is not ready and the controller is tracking and `DisableSkeletalModel` is false.
- Devices that already use `DisableSkeletalModel` + bound hands (ALVR, Quest serial/model heuristics, legacy flag) are unchanged.
- When skeleton is valid, behavior matches upstream (including resetting `hasBoundHand` from `DisableSkeletalModel`).
