### PR TITLE
Change FXAA settings

### DIFF
--- a/Assets/PostProcessing/Shaders/Builtins/FinalPass.shader
+++ b/Assets/PostProcessing/Shaders/Builtins/FinalPass.shader
@@ -22,19 +22,22 @@ Shader "Hidden/PostProcessing/FinalPass"
             // Luma is encoded in alpha after the first Uber pass
             #define FXAA_GREEN_AS_LUMA 0
         #endif
-
-        #if FXAA_LOW
-            #define FXAA_QUALITY__PRESET 12
-            #define FXAA_QUALITY_SUBPIX 1.0
-            #define FXAA_QUALITY_EDGE_THRESHOLD 0.166
-            #define FXAA_QUALITY_EDGE_THRESHOLD_MIN 0.0625
-        #else
-            #define FXAA_QUALITY__PRESET 28
-            #define FXAA_QUALITY_SUBPIX 1.0
-            #define FXAA_QUALITY_EDGE_THRESHOLD 0.063
-            #define FXAA_QUALITY_EDGE_THRESHOLD_MIN 0.0312
-        #endif
-
+        //I don't know if Resonite uses the FXAA_LOW variable, but considering how there isn't a way for the user to
+        //select low quality FXAA over high quality, I think it should be safe to just remove it.
+        //Commenting out instead of deleting just in case it is needed.
+        //#if FXAA_LOW
+        //    #define FXAA_QUALITY__PRESET 12
+        //    #define FXAA_QUALITY_SUBPIX 1.0
+        //    #define FXAA_QUALITY_EDGE_THRESHOLD 0.166
+        //    #define FXAA_QUALITY_EDGE_THRESHOLD_MIN 0.0625
+        //#else
+        
+        #define FXAA_QUALITY__PRESET 39 //used to be 28
+        #define FXAA_QUALITY_SUBPIX 0   //used to be 1.0, which is the max value. Could be a little higher than 0 if the increase in aliasing is too much, though increasing the value directly results in less clarity.
+        #define FXAA_QUALITY_EDGE_THRESHOLD 0.063//------|
+        #define FXAA_QUALITY_EDGE_THRESHOLD_MIN 0.0312//-|these two are basically how strong the FXAA edge detection is. Lower values = stronger edge detection.
+        //-----------------------------------------------|Not changing these for now, just to avoid changing too many values at once.
+        //#endif
         #include "FastApproximateAntialiasing.hlsl"
 
         TEXTURE2D_SAMPLER2D(_MainTex, sampler_MainTex);


### PR DESCRIPTION
## Main Changes
Increased the FXAA_QUALITY__PRESET to the highest quality value of 39. Should slightly increase quality of visuals, at minor performance costs. It's still just FXAA though, so it's probably not going to be that big of a deal.

Reduced FXAA_QUALITY_SUBPIX value to 0.
It was originally set to the maximum value of 1. Turning it off dramatically improves text clarity at the cost of slightly increased aliasing on things like small objects.

## Motivation
FXAA is currently the only Anti-Aliasing method that works in VR. The problem is that it also nukes text clarity. This PR should make FXAA a bit less blurry, and improve overall clarity

### Related GitHub issues
[Better anti-aliasing solution compatible with VR](https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/6)
I personally don't think the issue should be closed by this PR, as SMAA still looks a little better than FXAA and it _might_ be possible to get it working in VR.

## Testing
I haven't done too thorough testing yet. I've mainly just booted up the edited renderer on my laptop to see if the changes even did anything. All I can confirm as of right now is that the game still boots, and that the changed FXAA settings are applied properly. It _should_ still work in VR, as none of the actual FXAA functionality was changed. Would still probably be a good idea to test it though before a potential merge.

## Backwards Compatibility
These changes are just to some of the settings that get passed into FXAA by the FinalPass.shader file. The only thing that should be affected is the visuals from FXAA being turned on.

## Small note about the comments in the changed file
I left a handful of comments in the FinalPass.shader file describing things like why I commented out a small section, and what some of the other variables do. They aren't terribly important though, so feel free to delete them if you feel like it.