### PR TITLE
Make SMAA use Ultra preset instead of the High preset

### DIFF
--- a/Assets/PostProcessing/Shaders/Builtins/SubpixelMorphologicalAntialiasing.shader
+++ b/Assets/PostProcessing/Shaders/Builtins/SubpixelMorphologicalAntialiasing.shader
@@ -43,7 +43,7 @@ Shader "Hidden/PostProcessing/SubpixelMorphologicalAntialiasing"
 
                 #pragma vertex VertEdge
                 #pragma fragment FragEdge
-                #define SMAA_PRESET_HIGH
+                #define SMAA_PRESET_ULTRA //Since Resonite always uses the "high" unity setting, we only have to replace the "SMAA_PRESET_HIGH" instances with "SMAA_PRESET_ULTRA" to use the Ultra preset.
                 #include "SubpixelMorphologicalAntialiasingBridge.hlsl"
 
             ENDHLSL
@@ -82,7 +82,7 @@ Shader "Hidden/PostProcessing/SubpixelMorphologicalAntialiasing"
 
                 #pragma vertex VertBlend
                 #pragma fragment FragBlend
-                #define SMAA_PRESET_HIGH
+                #define SMAA_PRESET_ULTRA
                 #include "SubpixelMorphologicalAntialiasingBridge.hlsl"
 
             ENDHLSL


### PR DESCRIPTION
## Motivation
Currently we use the "High" SMAA preset, which can miss some edges

### Related GitHub issues
[Better anti-aliasing solution compatible with VR](https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/6)

## Notable Changes
Replaces instances of "SMAA_PRESET_HIGH" in the SubpixelMorphologicalAntialiasing.shader file with "SMAA_PRESET_ULTRA." We don't have to worry about other SMAA_PRESET_[...] settings because we currently only use the "high" setting. 

## Testing
The same testing I did with the "Update Post processing files" pr, as I had this change included when I was doing that testing. I didn't want the entire update post effects change to get rejected if this change's slight decrease in text readability is a problem, so I separated the changes into different PRs.

## Backwards Compatibility
Similarly to the FXAA changes I made a little while ago, this is just changing some files to use different pre-existing quality settings. It is borderline impossible for there to be any kind of severe breakage from this change.
The only potential issue is that the more aggressive settings slightly impacts text readability.
It's nowhere near as bad as something like the old FXAA where text would be unreadable if it was more than 2 feet from your face, but it's still a slight decrease in readability nonetheless.
_I_ think it would be worth it, but it's up to you if this gets merged.

## Comparison screenshots
SMAA High (current preset)
<img width="3440" height="1440" alt="smaa-high" src="https://github.com/user-attachments/assets/46d6b364-6e09-44ad-ba49-093ae05ffbe1" />

SMAA Ultra (this PR)
<img width="3440" height="1440" alt="smaa-ultra" src="https://github.com/user-attachments/assets/bae12089-5d74-459e-852f-66336ca6832a" />

The better antialiasing can be seen in how the "high" preset misses some of the guardrails (like the one that overlaps with the cloud home's dark wood in the distance) while the "ultra" preset catches those jaggies.
This _could_ slightly decrease performance when using SMAA, but in my experience a single pass of SMAA is not enough to cause any noticeable dips in performance, even if it's set set to the most aggressive possible settings.