### PR TITLE
Disable Screen Space Reflections if user is both in VR and selects SMAA

### DIFF
--- a/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
+++ b/Assets/APP/Unity Environment/CameraPostprocessingManager.cs
@@ -105,6 +105,7 @@ public class CameraPostprocessingManager : MonoBehaviour
         _motionBlur = _postProcessing.defaultProfile.GetSetting<MotionBlur>();
         _bloom = _postProcessing.defaultProfile.GetSetting<Bloom>();
         _ssr = _postProcessing.defaultProfile.GetSetting<ScreenSpaceReflections>();
+        _ssr.enabled.value = false;
     }
 
     void AddPostProcessing()

--- a/Assets/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
+++ b/Assets/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
@@ -142,6 +142,9 @@ namespace UnityEngine.Rendering.PostProcessing
         /// <returns><c>true</c> if the effect is currently enabled and supported</returns>
         public override bool IsEnabledAndSupported(PostProcessRenderContext context)
         {
+            if (context.antialiasing == PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing && RuntimeUtilities.isSinglePassStereoEnabled) //disables SSR if SMAA is used in VR.
+                return false;
+            else
             return enabled
                 && context.camera.actualRenderingPath == RenderingPath.DeferredShading
                 && SystemInfo.supportsMotionVectors

--- a/Assets/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
+++ b/Assets/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
@@ -142,7 +142,7 @@ namespace UnityEngine.Rendering.PostProcessing
         /// <returns><c>true</c> if the effect is currently enabled and supported</returns>
         public override bool IsEnabledAndSupported(PostProcessRenderContext context)
         {
-            if (context.antialiasing == PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing && RuntimeUtilities.isSinglePassStereoEnabled) //disables SSR if SMAA is used in VR.
+            if (context.antialiasing == PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing && context.camera.stereoEnabled == true) //disables SSR if SMAA is used in VR.
                 return false;
             else
             return enabled


### PR DESCRIPTION
I guess things like this is why Unity disabled SMAA for vr lol.

## Motivation
SMAA and SSR work together in desktop mode, but the rendering breaks if SSR & SMAA are enabled in VR.
This patch disables SSR if the player starts the game in VR & has SMAA set. ~~This lasts for the duration of the session.~~
~~I tried to implement something similar to how motion blur disables in vr but then re-enables if you switch to desktop, but I couldn't get it to work.~~
I managed to make the check less global, so now SSR re-enables itself if the user hits f8 to switch to desktop mode.
FXAA still works with SSR in VR, so it doesn't need this change.

### Related GitHub issues
[VR FrameBuffer rendering on both eyes](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6716)

## Notable Changes
The SSR .cs file now has an if statement in the `IsEnabledAndSupported` function. This function originally always returned that SSR was supported. Now it checks against `context.camera.stereoEnabled == true` and `context.antialiasing == PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing`, so that if both are true then the function returns false to disable SSR.

## Testing
I've ran the renderer through Monado's Simulated HMD, and SSR gets disabled if the user selects SMAA after starting the game in VR. This fixes the linked github issue.

## Backwards Compatibility
Nothing should break, as the SMAA+SSR in VR is the _only_ scenario this change effects.
~~The most breakage I can think of is _maybe_ cameras lose SSR if SMAA is active after starting the game in VR.~~
The change to checking the if the specific camera is using Stereo Rendering seems to be good enough to let cameras still have SSR if the user has SMAA active while in VR.