### PR TITLE
Re-comment out some code in PostProcessLayer.cs

### DIFF
--- a/Assets/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/Assets/PostProcessing/Runtime/PostProcessLayer.cs
@@ -1343,12 +1343,12 @@ namespace UnityEngine.Rendering.PostProcessing
                     cmd.BlitFullscreenTriangleToDoubleWide(context.source, context.destination, uberSheet, 0, eye);
                 }
                 else
-#if LWRP_1_0_0_OR_NEWER || UNIVERSAL_1_0_0_OR_NEWER
+//#if LWRP_1_0_0_OR_NEWER || UNIVERSAL_1_0_0_OR_NEWER
                     cmd.BlitFullscreenTriangle(context.source, context.destination, uberSheet, 0, false, context.camera.pixelRect);
-#else
-                    cmd.BlitFullscreenTriangle(context.source, context.destination, uberSheet, 0);
-#endif
-
+//#else
+//                    cmd.BlitFullscreenTriangle(context.source, context.destination, uberSheet, 0);
+//#endif
+//The code above was un-commented out in the post processing update, causing issue 6722. Commenting it out again fixes it.
                 if (tempTarget > -1)
                     cmd.ReleaseTemporaryRT(tempTarget);
             }


### PR DESCRIPTION
## Motivation
The Post Processing update pr I made accidentally caused some cameras to break a little with post processing.
There was a very small section of code that was originally commented out in this file before the post processing update. It got un-commented out, which caused issue 6722 to happen. Re-commenting out the aforementioned code fixes the issue.

### Related GitHub issues
[Viewport setting broken on camera component](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6722)

## Notable Changes
Just re-comments out some code that should've stayed commented out. 

## Testing
I ran the game in both desktop mode and in VR using Monado's Simulated HMD. This change fixes 6722 while still preserving the "Vertical lines are properly anti-aliased" fix that the post processing update was made for.

## Backwards Compatibility
This isn't expected to break anything, as it's reverting a little bit of code to fix broken behaviors.