### PR TITLE
Add monitor handles

### DIFF
--- a/Assets/APP/Renderite/Renderite.Shared.dll
+++ b/Assets/APP/Renderite/Renderite.Shared.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90b796c18cf6f171ee5d03df2ef0babb850a7a5f2ebf97054ef2c223e356e4c3
+oid sha256:76f6fd6086fea3bdc46a9f9cd11f1efb089e1cde46fbaf863fc26bf147d89f35
 size 123392

--- a/Assets/APP/Renderite/Renderite.Unity.dll
+++ b/Assets/APP/Renderite/Renderite.Unity.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d750fe2ed73aa3ee0fb8267263a43e4cf31369b7a56162ffcb2651ce2f63d84a
+oid sha256:9624ba1c70da09f7452552b33d5c25846b88fc2769e886b746bf0a24ad0d7a7f
 size 239104

--- a/Assets/APP/Unity Environment/InputOutputDrivers/DisplayDriver.cs
+++ b/Assets/APP/Unity Environment/InputOutputDrivers/DisplayDriver.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System;
 using Renderite.Shared;
 using Renderite.Unity;
+using System.Linq;
 
 #if UNITY_STANDALONE_WIN
 
@@ -11,6 +12,9 @@ public class DuplicableDisplay : IDisplayTextureSource
 {
     uDesktopDuplication.Monitor _monitor;
     uWindowCapture.UwcWindow _window;
+
+    uDesktopDuplication.Monitor _handleMonitor;
+    ulong _handle;
 
     enum State
     {
@@ -26,7 +30,7 @@ public class DuplicableDisplay : IDisplayTextureSource
 
     public Texture UnityTexture => _window?.texture ?? _monitor?.texture;
 
-    public DuplicableDisplay(int index)
+    public DuplicableDisplay()
     {
 
     }
@@ -41,8 +45,31 @@ public class DuplicableDisplay : IDisplayTextureSource
         state.isPrimary = monitor.isPrimary;
     }
 
-    public void Update(uDesktopDuplication.Monitor monitor, DisplayState state)
+    public void Update(uDesktopDuplication.Monitor monitor, DisplayState state, ref List<WindowsMonitorApi.Monitor> monitorInfo)
     {
+        if (_handleMonitor != monitor)
+        {
+            if (monitorInfo == null)
+                monitorInfo = WindowsMonitorApi.QueryDisplayDevices();
+
+            var info = monitorInfo.FirstOrDefault(m => string.Equals(m.deviceID, monitor.name));
+
+            if (info == null)
+            {
+                Debug.LogWarning($"Failed to fetch handle for monitor: {monitor.name}\nDetected Monitors:\n" +
+                    $"{string.Join("\n", monitorInfo.Select(m => $"{m.name}, DeviceID: {m.deviceID}, Handle: 0x{m.handle:X}") )}");
+
+                _handle = 0;
+            }
+            else
+            {
+                _handle = info.handle;
+                Debug.Log($"Monitor {monitor.name} handle: 0x{_handle:X}");
+            }
+
+            _handleMonitor = monitor;
+        }
+
         if (_requests.Count == 0)
         {
             _monitor = null;
@@ -172,6 +199,8 @@ public class DisplayDriver : DisplayInput
     {
         var monitors = uDesktopDuplication.Manager.monitors;
 
+        List<WindowsMonitorApi.Monitor> monitorInfo = null;
+
         for (int i = 0; i < monitors.Count; i++)
         {
             var monitor = monitors[i];
@@ -192,15 +221,23 @@ public class DisplayDriver : DisplayInput
 
             if (_displays.Count == i)
             {
-                display = new DuplicableDisplay(i);
+                display = new DuplicableDisplay();
 
                 _displays.Add(display);
             }
             else
                 display = _displays[i];
 
-            display.Update(monitor, state);
+            display.Update(monitor, state, ref monitorInfo);
         }
+
+        // Remove any extras
+        // TODO!!! Is there need for disposal? Generally this doesn't happen often
+        while(_displays.Count > monitors.Count)
+            _displays.RemoveAt(_displays.Count - 1);
+
+        while (states.Count > monitors.Count)
+            states.RemoveAt(states.Count - 1);
     }
 #else
 

--- a/Assets/APP/Unity Environment/InputOutputDrivers/DisplayDriver.cs
+++ b/Assets/APP/Unity Environment/InputOutputDrivers/DisplayDriver.cs
@@ -28,7 +28,10 @@ public class DuplicableDisplay : IDisplayTextureSource
 
     HashSet<Action> _requests = new HashSet<Action>();
 
-    public Texture UnityTexture => _window?.texture ?? _monitor?.texture;
+    public Texture UnityTexture => _texture;
+    public Texture SourceTexture => _window?.texture ?? _monitor?.texture;
+
+    RenderTexture _texture;
 
     public DuplicableDisplay()
     {
@@ -37,6 +40,7 @@ public class DuplicableDisplay : IDisplayTextureSource
 
     void UpdateProperties(uDesktopDuplication.Monitor monitor, DisplayState state)
     {
+        state.monitorHandle = _handle;
         state.resolution = new RenderVector2i(monitor.width, monitor.height);
         state.refreshRate = -1;
         state.orientation = currentState == State.UsingWindowCapture ? RectOrientation.Default : ToEngine(monitor.rotation);
@@ -129,6 +133,21 @@ public class DuplicableDisplay : IDisplayTextureSource
             changed = true;
             currentState = State.UsingWindowCapture;
         }
+
+        var source = SourceTexture;
+
+        if (source != null && (_texture == null || _texture.width != source.width || _texture.height != source.height))
+        {
+            if (_texture != null)
+            {
+                UnityEngine.Object.Destroy(_texture);
+                _texture = null;
+            }
+
+            _texture = new RenderTexture(source.width, source.height, 0, UnityEngine.Experimental.Rendering.DefaultFormat.LDR);
+        }
+
+        Graphics.Blit(source, _texture, new Vector2(1, -1), new Vector2(0, 1));
 
         UpdateProperties(monitor, state);
 

--- a/Assets/APP/Unity Environment/WindowsMonitorAPI.cs
+++ b/Assets/APP/Unity Environment/WindowsMonitorAPI.cs
@@ -1,0 +1,149 @@
+﻿#if UNITY_STANDALONE_WIN
+
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class WindowsMonitorApi
+{
+    public class Monitor
+    {
+        public ulong handle;
+        public string name;
+        public string deviceID;
+    }
+
+    public static List<Monitor> QueryDisplayDevices()
+    {
+        var monitors = new List<Monitor>();
+        
+        MonitorEnumDelegate MonitorEnumProc = new MonitorEnumDelegate((IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData) =>
+        {
+            MONITORINFOEX mi = new MONITORINFOEX() { Size = Marshal.SizeOf(typeof(MONITORINFOEX)) };
+
+            if (GetMonitorInfo(hMonitor, ref mi))
+            {
+                DISPLAY_DEVICE device = new DISPLAY_DEVICE();
+                device.Initialize();
+
+                if (EnumDisplayDevices(mi.DeviceName.ToLPTStr(), 0, ref device, 0))
+                {
+                    var display = new Monitor()
+                    {
+                        handle = unchecked((ulong)hMonitor.ToInt64()),
+                        name = device.DeviceString,
+                        deviceID = mi.DeviceName,
+                    };
+
+                    monitors.Add(display);
+                }
+            }
+
+            return true;
+        });
+
+        EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, MonitorEnumProc, IntPtr.Zero);
+
+        return monitors;
+    }
+
+    #region DISPLAY_DEVICE struct
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAY_DEVICE
+    {
+        public int cb;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DeviceName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceString;
+        public DisplayDeviceStateFlags StateFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceID;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string DeviceKey;
+
+        public void Initialize()
+        {
+            cb = 0;
+            DeviceName = new string((char)32, 32);
+            DeviceString = new string((char)32, 128);
+            DeviceID = new string((char)32, 128);
+            DeviceKey = new string((char)32, 128);
+            cb = Marshal.SizeOf(this);
+        }
+    }
+    #endregion
+
+    #region RECT struct
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+    #endregion
+
+    #region MONITORINFOEX struct
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct MONITORINFOEX
+    {
+        public int Size;
+        public RECT Monitor;
+        public RECT WorkArea;
+        public uint Flags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DeviceName;
+    }
+    #endregion
+
+    #region DisplayDeviceStateFlags enum
+    [Flags()]
+    public enum DisplayDeviceStateFlags : int
+    {
+        /// <summary>The device is part of the desktop.</summary>
+        AttachedToDesktop = 0x1,
+        MultiDriver = 0x2,
+        /// <summary>The device is part of the desktop.</summary>
+        PrimaryDevice = 0x4,
+        /// <summary>Represents a pseudo device used to mirror application drawing for remoting or other purposes.</summary>
+        MirroringDriver = 0x8,
+        /// <summary>The device is VGA compatible.</summary>
+        VGACompatible = 0x10,
+        /// <summary>The device is removable; it cannot be the primary display.</summary>
+        Removable = 0x20,
+        /// <summary>The device has more display modes than its output devices support.</summary>
+        ModesPruned = 0x8000000,
+        Remote = 0x4000000,
+        Disconnect = 0x2000000,
+    }
+    #endregion
+
+    public delegate bool MonitorEnumDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumDelegate lpfnEnum, IntPtr dwData);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+    [DllImport("User32.dll")]
+    internal static extern bool EnumDisplayDevices(byte[] lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, int dwFlags);
+
+    public static byte[] ToLPTStr(this string str)
+    {
+        var lptArray = new byte[str.Length + 1];
+
+        var index = 0;
+        foreach (char c in str.ToCharArray())
+            lptArray[index++] = Convert.ToByte(c);
+
+        lptArray[index] = Convert.ToByte('\0');
+
+        return lptArray;
+    }
+}
+
+#endif

--- a/Assets/APP/Unity Environment/WindowsMonitorAPI.cs.meta
+++ b/Assets/APP/Unity Environment/WindowsMonitorAPI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58ddb0c7d8199fc49abddc976b60a420
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Motivation
I've been working on adding desktop streaming as my creative day project. One of the pre-requisites for this is ability to match the screens reported by the renderer for the capture, which requires a monitor handle.

Since this requires a small breaking change to the IPC mechanism, I've separated this change out into this PR to avoid having to switch renderers back and forth.

### Related GitHub issues
https://github.com/Yellow-Dog-Man/Renderite/pull/16

## Notable Changes
- Added API to fetch the monitor handle via the Windows API
- Added code to match the uDesktopDuplication monitor to the handle and provide it with the IPC data about the screen
- Added mechanism that flips the desktop texture upside down
    - This simplifies a lot of things for the desktop share, because it makes the texture orientation consistent with the video stream of it

## Testing
Tested the renderer with a corresponding build of Resonite, which prints out the captured monitor handles to the log.

## Backwards Compatibility
> [!CAUTION]
> This has two breaking changes - one to the IPC and one to the desktop texture orientation.
> If you're making any custom renderers, you will need to update your IPC models, otherwise they will crash once new version of with these changes ships.

Keep an eye on the changelog, I'll leave a note there that this change has been made.