### PR TITLE
Windows IME composition/preedit payload over Renderite KeyboardState

### DIFF
--- a/Assets/APP/Unity Environment/InputOutputDrivers/KeyboardDriver.cs
+++ b/Assets/APP/Unity Environment/InputOutputDrivers/KeyboardDriver.cs
@@ -193,6 +193,9 @@ public class KeyboardDriver : KeyboardInput
 
     public override void HandleOutputState(OutputState output)
     {
+        if (output.compositionCursorPosition != null)
+            Input.compositionCursorPos = output.compositionCursorPosition.Value.ToUnity();
+
         if(output.keyboardInputActive != _lastKeyboardActive)
         {
             _lastKeyboardActive = output.keyboardInputActive;

--- a/Assets/APP/Unity Environment/InputOutputDrivers/KeyboardDriver.cs
+++ b/Assets/APP/Unity Environment/InputOutputDrivers/KeyboardDriver.cs
@@ -175,6 +175,10 @@ public class KeyboardDriver : KeyboardInput
     protected override void UpdateState(KeyboardState state)
     {
         state.typeDelta = GetTypeDelta();
+        var compositionText = UnityEngine.Input.compositionString;
+        var compositionActive = !string.IsNullOrEmpty(compositionText);
+        state.compositionActive = compositionActive;
+        state.compositionText = compositionActive ? compositionText : null;
 
         // Collect the currently held keys
         if (state.heldKeys == null)


### PR DESCRIPTION
## Motivation

This PR adds the Unity renderer side of Windows IME composition support.

On Windows desktop, the Unity renderer owns the OS window and can read Unity's IME composition state. The current shared keyboard path sends committed text through `typeDelta` and physical key state through `heldKeys`, but it does not send IME composition state to FrooxEngine.

This PR keeps the renderer-side change small:

- read Unity's current IME composition string
- send it through `KeyboardState.compositionActive` and `KeyboardState.compositionText`
- apply the text caret anchor position from `OutputState.compositionCursorPosition` to Unity's IME window position API

The standard Windows IME candidate window is used. This PR does not add a custom candidate UI.

### Related GitHub issues

- Implements the Unity renderer side of:
  - https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/21
- Parent user-facing issue:
  - https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/745
- Related symptom:
  - https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2825

Related PRs:

- Requires the matching Renderite shared model PR:
  - https://github.com/Yellow-Dog-Man/Renderite/pull/17

FrooxEngine-side text editing handling is also required. The minimum required engine behavior is:

- consume `KeyboardState.compositionActive` and `KeyboardState.compositionText`
- keep committed text handling on the existing `typeDelta` path
- keep `compositionText` separate from committed text content
- present `compositionText` in Userspace near the text caret while `compositionActive` is true, without committing it into the target text content
- avoid treating IME composition keystrokes as normal text editor control input while `compositionActive` is true
- calculate the text caret anchor position in window coordinates
- send that caret anchor position to the renderer through `OutputState.compositionCursorPosition`

Reference code for those FrooxEngine-side behaviors is available here:

- Input interface integration, composition-key suppression, composition state update, and output-state update:
  - https://github.com/esnya/RenderiteImeIntegration/blob/main/ImeIntegration/Patches/InputInterfacePatches.cs
- Text editor focus/defocus tracking:
  - https://github.com/esnya/RenderiteImeIntegration/blob/main/ImeIntegration/Patches/TextEditorPatches.cs
- Composition overlay update and caret-anchor calculation:
  - https://github.com/esnya/RenderiteImeIntegration/blob/main/ImeIntegration/Windows/WindowsImeOverlayManager.cs

These files are reference code for the required FrooxEngine behavior. They are not part of this renderer PR and are not intended to be merged as-is. As these are Harmony patches, they make use of reflection.

## Notable Changes

- Reads `UnityEngine.Input.compositionString` in `KeyboardDriver.UpdateState`.
- Sets `KeyboardState.compositionActive` when Unity reports a non-empty composition string.
- Sets `KeyboardState.compositionText` to the current composition string while composition is active.
- Clears `KeyboardState.compositionText` to `null` when composition is not active.
- Applies `OutputState.compositionCursorPosition`, when provided by the engine side, to `Input.compositionCursorPos`.

`OutputState.compositionCursorPosition` is the text caret anchor position in window coordinates. The Unity renderer passes it to Unity's IME placement API.

## Limitations

This is not a complete low-level Windows IME implementation.

Known limitations:

- This implementation cannot handle selection or clause/segment information inside the composition string. Unity exposes the composition string, but it does not provide the lower-level IME state needed for full composition range handling.
- Full IME support would require a lower-level Windows IME API implementation.
- The standard IME candidate window may stay at the position where it was first opened. If the user moves the view while IME composition is active, the candidate window can become offset from the text caret.
- This PR covers physical keyboard input only. Resonite's virtual keyboard is not supported by this implementation.

## Testing

Tested with:

- Resonite Beta 2026.6.24.835
- Windows 11 Pro 25H2 26200.8655
- Microsoft IME
- Renderite shared model change from:
  - TODO: <Renderite PR URL>
- Unity renderer change from this PR
- FrooxEngine-side reference implementation:
  - https://github.com/esnya/RenderiteImeIntegration

Verified behavior:

- Japanese IME composition state is forwarded from Unity to the engine-side reference implementation.
- `compositionActive` and `compositionText` are updated while IME composition is active.
- Active composition text is shown near the caret by the engine-side reference overlay without committing it into the target text content.
- Committed text still goes through the existing `typeDelta` path.
- The standard Microsoft IME candidate window is used.
- The IME candidate window opens near the caret when the engine side provides a caret anchor position.
- Non-IME physical keyboard input still works through the existing keyboard path.

I have not tested this as a full official FrooxEngine implementation, because the required FrooxEngine-side changes are not part of this repository.

## Backwards Compatibility

Committed text is still sent through the existing `typeDelta` path.

This PR is not intended to change existing non-IME text input behavior. It changes the IPC data model, so Renderite.Shared, FrooxEngine, and Renderite.Unity.Renderer must be updated together.




## Screen Capture

Once all the changes are in place, we will be able to enter text, albeit in a very basic way. Up to now, we have been entering text whilst all of this remained invisible.

<img width="2045" height="1013" alt="image" src="https://github.com/user-attachments/assets/6d3fa10f-517c-4f91-b301-b026a08d5407" />
