### PR TITLE
Add support for additional source for video playback

### DIFF
--- a/Assets/APP/Renderite/Renderite.Shared.dll
+++ b/Assets/APP/Renderite/Renderite.Shared.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87e08463ca3eb980554e1d8609a01fd6ba44d17cf15dcaa395ffbe9711c72158
+oid sha256:f97e13274347c339ddf92ab93240ea597b261442db2c92a5ff5bb5af6abccc8f
 size 123904

--- a/Assets/APP/Renderite/Renderite.Unity.dll
+++ b/Assets/APP/Renderite/Renderite.Unity.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f49fd2ee51b4b2c7919f19894ec1a2d38a515a8aedf93ab6bb88dae0d2682de
+oid sha256:209e1b9e16d2a1246ab60d214a1935f9e98f91bff76fc8397fb3eee6155650b5
 size 240128

--- a/Assets/APP/Unity Environment/Connectors/UMPVideoTextureBehaviour.cs
+++ b/Assets/APP/Unity Environment/Connectors/UMPVideoTextureBehaviour.cs
@@ -133,9 +133,6 @@ public class UMPVideoTextureBehaviour : MonoBehaviour, IVideoPlaybackInstance
     {
         PlayerOptions options = new PlayerOptions(null);
 
-        if(!string.IsNullOrEmpty(additionalSource))
-            options.SetValue("--input-slave", additionalSource);
-
         switch (UMPSettings.RuntimePlatform)
         {
             case UMPSettings.Platforms.Win:
@@ -199,6 +196,9 @@ public class UMPVideoTextureBehaviour : MonoBehaviour, IVideoPlaybackInstance
                 options = iphoneOptions;
                 break;
         }
+
+        if (!string.IsNullOrEmpty(additionalSource))
+            options.SetValue("--input-slave", additionalSource);
 
         mediaPlayer = new MediaPlayer(this, null as GameObject[], options, outputSampleRate);
 

--- a/Assets/APP/Unity Environment/Connectors/UMPVideoTextureBehaviour.cs
+++ b/Assets/APP/Unity Environment/Connectors/UMPVideoTextureBehaviour.cs
@@ -24,6 +24,7 @@ public class UMPVideoTextureBehaviour : MonoBehaviour, IVideoPlaybackInstance
     MediaPlayerStandalone standalonePlayer;
 
     string dataSource;
+    string additionalSource;
 
     public UnityEngine.Texture Texture => _texture;
 
@@ -96,13 +97,13 @@ public class UMPVideoTextureBehaviour : MonoBehaviour, IVideoPlaybackInstance
             _initialized = true;
     }
 
-    public IEnumerator Setup(VideoTextureAsset asset, string dataSource, int audioSystemSampleRate)
+    public IEnumerator Setup(VideoTextureAsset asset, string dataSource, string additionalSource, int audioSystemSampleRate)
     {
-        Debug.Log("Preparing UMP: " + dataSource + $", AssetId: {asset.AssetId}");
+        Debug.Log($"Preparing UMP: {dataSource} (Additional: {additionalSource}), AssetId: {asset.AssetId}");
 
         sampleRate = audioSystemSampleRate;
 
-        InitializePlayer(audioSystemSampleRate);
+        InitializePlayer(additionalSource, audioSystemSampleRate);
 
         this.asset = asset;
         this.dataSource = dataSource;
@@ -128,9 +129,12 @@ public class UMPVideoTextureBehaviour : MonoBehaviour, IVideoPlaybackInstance
         }
     }
 
-    void InitializePlayer(int outputSampleRate)
+    void InitializePlayer(string additionalSource, int outputSampleRate)
     {
         PlayerOptions options = new PlayerOptions(null);
+
+        if(!string.IsNullOrEmpty(additionalSource))
+            options.SetValue("--input-slave", additionalSource);
 
         switch (UMPSettings.RuntimePlatform)
         {

--- a/Assets/APP/Unity Environment/Connectors/UnityVideoTextureBehaviour.cs
+++ b/Assets/APP/Unity Environment/Connectors/UnityVideoTextureBehaviour.cs
@@ -77,9 +77,15 @@ public class UnityVideoTextureBehavior : MonoBehaviour, IVideoPlaybackInstance
 
     bool playing;
 
-    public IEnumerator Setup(VideoTextureAsset asset, string dataSource, int audioSystemSampleRate)
+    public IEnumerator Setup(VideoTextureAsset asset, string dataSource, string additionalSource, int audioSystemSampleRate)
     {
-        Debug.Log("Preparing UnityVideoTexture: " + dataSource + $", AssetId: {asset.AssetId}");
+        Debug.Log($"Preparing UnityVideoTexture: {dataSource} (Additional: {additionalSource}), AssetId: {asset.AssetId}");
+
+        if (!string.IsNullOrEmpty(additionalSource))
+        {
+            Debug.LogWarning("UnityVideoTexture does not support additional source");
+            yield break;
+        }
 
         try
         {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,8 +124,9 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2026.8.31.804
+  bundleVersion: 2026.8.31.1206
   preloadedAssets:
+  - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2026.8.28.1126
+  bundleVersion: 2026.8.31.804
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}


### PR DESCRIPTION
## Motivation
Playing YouTube videos keeping running into issues where there's no good format that has both audio & video. 

To solve this, this adds support for a additional source URL for video playback, which allows live muxing two input sources - separate video & audio streams.

### Related GitHub issues
https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6970

## Notable Changes
- UMP playback engine will now use the `--input-slave` option when additional source is provided
- UnityVideoPlayer will not be used when additional source is provided due to Unity engine not supporting this option

## Testing
Loaded YouTube videos with separate video & audio streams, which would play both audio & video at the same time!

## Backwards Compatibility
This contains breaking changes for the IPC model for loading videos. This doesn't affect any user content, but will affect custom community renderers.